### PR TITLE
Add unit tests to check path is expanded

### DIFF
--- a/tests/pytests/unit/config/test_master_config.py
+++ b/tests/pytests/unit/config/test_master_config.py
@@ -1,4 +1,5 @@
 import salt.config
+from tests.support.mock import MagicMock, patch
 
 
 def test_apply_no_cluster_id():
@@ -60,3 +61,14 @@ def test_apply_for_cluster():
     assert isinstance(opts["cluster_peers"], list)
     opts["cluster_peers"].sort()
     assert ["127.0.0.1", "127.0.0.3"] == opts["cluster_peers"]
+
+
+def test___cli_path_is_expanded():
+    defaults = salt.config.DEFAULT_MASTER_OPTS.copy()
+    overrides = {}
+    with patch(
+        "salt.utils.path.expand", MagicMock(return_value="/path/to/testcli")
+    ) as expand_mock:
+        opts = salt.config.apply_master_config(overrides, defaults)
+        assert expand_mock.called
+        assert opts["__cli"] == "testcli"

--- a/tests/pytests/unit/config/test_minion_config.py
+++ b/tests/pytests/unit/config/test_minion_config.py
@@ -1,0 +1,13 @@
+import salt.config
+from tests.support.mock import MagicMock, patch
+
+
+def test___cli_path_is_expanded():
+    defaults = salt.config.DEFAULT_MINION_OPTS.copy()
+    overrides = {}
+    with patch(
+        "salt.utils.path.expand", MagicMock(return_value="/path/to/testcli")
+    ) as expand_mock:
+        opts = salt.config.apply_minion_config(overrides, defaults)
+        assert expand_mock.called
+        assert opts["__cli"] == "testcli"


### PR DESCRIPTION
### What does this PR do?

This PR adds few tests to `set-proper-__cli` branch, therefore to https://github.com/saltstack/salt/pull/65435